### PR TITLE
Tweak Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,73 @@
+# Set this to any non-empty string to enable unoptimized
+# build w/ debugging features.
+debug ?=
+
+# All complication artifacts, including dependencies and intermediates
+# will be stored here, for all architectures.  Use a non-default name
+# since the (default) 'target' is used/referenced ambiguously in many
+# places in the tool-chain (including 'make' itself).
+CARGO_TARGET_DIR ?= target
+export CARGO_TARGET_DIR  # 'cargo' is sensitive to this env. var. value.
+
+ifdef debug
+$(info debug is $(debug))
+  # These affect both $(CARGO_TARGET_DIR) layout and contents
+  # Ref: https://doc.rust-lang.org/cargo/guide/build-cache.html
+  release :=
+  profile :=debug
+else
+  release :=--release
+  profile :=release
+endif
 
 # Run all builds on 4 cpus
 build-release:
 	cargo build --release -j 4
 
-build:
-	cargo build -j 4
+
+.PHONY: all
+all: client build
+
+bin:
+	mkdir -p $@
+
+$(CARGO_TARGET_DIR):
+	mkdir -p $@
+
+
+.PHONY: build
+build: bin $(CARGO_TARGET_DIR)
+	cargo build -j 4 $(release)
+	cp $(CARGO_TARGET_DIR)/$(profile)/netavark_proxy bin/netavark-proxy$(if $(debug),.debug,)
 
 clean:
+	rm -fr bin
 	cargo clean
 	rm -f proto-build/netavark_proxy.rs
 
 server:
 	cargo run -j 4 --bin server
 
-client:
-	cargo run  -j 4 --bin client
+client: bin $(CARGO_TARGET_DIR)
+	cargo build -j 4 $(release)
+	cp $(CARGO_TARGET_DIR)/$(profile)/client bin/client$(if $(debug),.debug,)
 
-test:
+
+.PHONY: test
+test: unit integration
+
+.PHONY: unit
+unit: $(CARGO_TARGET_DIR)
 	cargo test
+
+.PHONY: integration
+integration: $(CARGO_TARGET_DIR)
+	bats test/
+
+.PHONY: validate
+validate: $(VARGO_TARGET_DIR)
+	cargo fmt --all -- --check
+	cargo clippy --no-deps
 
 help:
 	@printf '%s\n' \

--- a/README.md
+++ b/README.md
@@ -20,18 +20,15 @@ I have a web-based service that runs from a container.  While I know I can expos
 
 ## Build
 ```
-make build
-make build-release
+$ make
+$ make build-release
 ```
 
-## Server and client
-These commands run the server and client demo
-```
-make server
-make client
+## Testing
 ```
 
-## Test
-```
-make test
+You can run make test to run both unit and integration tests.  There are also make targets
+for `unit` and `integration` that can be run separately.
+
+$ make test
 ```

--- a/test/001-basic.bats
+++ b/test/001-basic.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# basic netavark tests
+#
+
+load helpers
+
+@test "simple example" {
+}
+

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,11 @@
+# netavark-proxy integration test with bats
+
+## Running tests
+
+To run the tests locally in your sandbox, you can use one of these methods:
+* bats ./test/001-basic.bats  # runs just the specified test
+* bats ./test/                # runs all
+
+## Requirements
+- bats
+- jq

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,0 +1,9 @@
+# -*- bash -*-
+
+# Netavark binary to run
+NETAVARK=${NETAVARK:-./bin/netavark}
+
+TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
+
+# export RUST_BACKTRACE so that we get a helpful stack trace
+export RUST_BACKTRACE=full


### PR DESCRIPTION
Some tweaks for the Makefile that allow for more granular testing.  Also
created some .PHONY targets for building the proxy and the client.  This
should be a good start.  More tightening will be required later but I
didn't want to go overboard because we will likely be able to leverage
netavarks Makefile at some point (when we merge?)

Added `validate` target.  This runs cargo fmt and clippy to ensure code
is clean and valid.  Consider running this before each commit.

Signed-off-by: Brent Baude <bbaude@redhat.com>